### PR TITLE
Cache guild configs and have bot prefixes per guild

### DIFF
--- a/snek/__main__.py
+++ b/snek/__main__.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 snek = Snek(
     command_prefix=when_mentioned_or('!'),
-    activity=discord.Game(name='Commands: !help'),
+    activity=discord.Activity(name='over everyone.', type=discord.ActivityType.watching),
     case_insensitive=True,
     max_messages=10_000
 )

--- a/snek/bot.py
+++ b/snek/bot.py
@@ -1,7 +1,8 @@
 import logging
 import typing as t
 
-from discord.ext.commands import Bot, Cog
+import discord
+from discord.ext.commands import Bot, Cog, when_mentioned_or
 
 from snek.api import APIClient
 
@@ -29,3 +30,7 @@ class Snek(Bot):
         """Close the Discord and API Client connection."""
         await super().close()
         await self.api_client.close()
+
+    async def get_prefix(self, message: discord.Message) -> str:
+        """Returns the prefix for the guild where a command was invoked."""
+        return when_mentioned_or(self.configs[message.guild.id]['command_prefix'])(self, message)

--- a/snek/bot.py
+++ b/snek/bot.py
@@ -1,4 +1,5 @@
 import logging
+import typing as t
 
 from discord.ext.commands import Bot, Cog
 
@@ -15,6 +16,9 @@ class Snek(Bot):
         log.info('Snek initializing..')
 
         self.api_client = APIClient(loop=self.loop)
+
+        # Syncer takes care of this
+        self.configs: t.Optional[t.Dict[int, str]] = None
 
     def add_cog(self, cog: Cog) -> None:
         """Adds a cog to the bot and logs the operation."""

--- a/snek/exts/config.py
+++ b/snek/exts/config.py
@@ -77,6 +77,7 @@ class Config(Cog):
             await ctx.send('❌ There is no such config key.')
 
     def cog_check(self, ctx: Context) -> bool:
+        """Only administrators can use this cog."""
         return ctx.author.permissions_in(ctx.channel).administrator
 
 

--- a/snek/exts/config.py
+++ b/snek/exts/config.py
@@ -57,25 +57,22 @@ class Config(Cog):
     @config_group.command(name='get', aliases=('g',))
     async def get_command(self, ctx: Context, key: str) -> None:
         """Get the value of `key` from a guild's config."""
-        if key not in CONFIG_DEFAULTS:
+        if (value := CONFIG_DEFAULTS.get(key)) is not None:
+            await ctx.send(f'The value of `{key}` is `{value}`.')
+        else:
             await ctx.send('❌ There is no such config key.')
-            return
-
-        config = await self.bot.api_client.get(f'guild_configs/{ctx.guild.id}')
-        await ctx.send(f'The value of `{key}` is `{config[key]}`.')
 
     @config_group.command(name='reset', aliases=('r',))
     async def reset_command(self, ctx: Context, key: str) -> None:
         """Reset the value of `key` in a guild's config."""
-        if key not in CONFIG_DEFAULTS:
+        if (value := CONFIG_DEFAULTS.get(key)) is not None:
+            await self.bot.api_client.patch(
+                f'guild_configs/{ctx.guild.id}',
+                json={key: value}
+            )
+            await ctx.send(f'✅ Config key `{key}` was sucessfully reset.')
+        else:
             await ctx.send('❌ There is no such config key.')
-            return
-
-        await self.bot.api_client.patch(
-            f'guild_configs/{ctx.guild.id}',
-            json={key: CONFIG_DEFAULTS[key]}
-        )
-        await ctx.send(f'✅ Config key `{key}` was sucessfully reset.')
 
     def cog_check(self, ctx: Context) -> bool:
         return ctx.author.permissions_in(ctx.channel).administrator

--- a/snek/exts/config.py
+++ b/snek/exts/config.py
@@ -46,6 +46,8 @@ class Config(Cog):
                 f'guild_configs/{ctx.guild.id}',
                 json={key: value}
             )
+            self.bot.configs[ctx.guild.id][key] = value
+
             await ctx.send(f'✅ Config key `{key}` successfully updated.')
 
     @config_group.command(name='get', aliases=('g',))

--- a/snek/exts/config.py
+++ b/snek/exts/config.py
@@ -72,7 +72,7 @@ class Config(Cog):
             )
             self.bot.configs[ctx.guild.id][key] = value
 
-            await ctx.send(f'✅ Config key `{key}` was sucessfully reset.')
+            await ctx.send(f'✅ Config key `{key}` was sucessfully reset to `{value}`')
         else:
             await ctx.send('❌ There is no such config key.')
 

--- a/snek/exts/config.py
+++ b/snek/exts/config.py
@@ -57,8 +57,8 @@ class Config(Cog):
     @config_group.command(name='get', aliases=('g',))
     async def get_command(self, ctx: Context, key: str) -> None:
         """Get the value of `key` from a guild's config."""
-        if (value := CONFIG_DEFAULTS.get(key)) is not None:
-            await ctx.send(f'The value of `{key}` is `{value}`.')
+        if (value := self.bot.configs[ctx.guild.id].get(key)) is not None:
+            await ctx.send(f'The value of `{key}` is {value}')
         else:
             await ctx.send('❌ There is no such config key.')
 

--- a/snek/exts/config.py
+++ b/snek/exts/config.py
@@ -70,6 +70,8 @@ class Config(Cog):
                 f'guild_configs/{ctx.guild.id}',
                 json={key: value}
             )
+            self.bot.configs[ctx.guild.id][key] = value
+
             await ctx.send(f'✅ Config key `{key}` was sucessfully reset.')
         else:
             await ctx.send('❌ There is no such config key.')

--- a/snek/exts/config.py
+++ b/snek/exts/config.py
@@ -7,7 +7,7 @@ from snek.bot import Snek
 
 log = logging.getLogger(__name__)
 
-CONFIG_KEYS = ('mod_role', 'admin_role')
+CONFIG_KEYS = ('mod_role', 'admin_role', 'command_prefix')
 
 
 async def convert_config_value(ctx: Context, key: str, value: str) -> t.Any:
@@ -18,6 +18,8 @@ async def convert_config_value(ctx: Context, key: str, value: str) -> t.Any:
     if key in ('mod_role', 'admin_role'):
         role_converter = RoleConverter()
         return (await role_converter.convert(ctx, value)).id
+
+    return value
 
 
 class Config(Cog):

--- a/snek/exts/config.py
+++ b/snek/exts/config.py
@@ -7,12 +7,16 @@ from snek.bot import Snek
 
 log = logging.getLogger(__name__)
 
-CONFIG_KEYS = ('mod_role', 'admin_role', 'command_prefix')
+CONFIG_DEFAULTS = {
+    'mod_role': None,
+    'admin_role': None,
+    'command_prefix': '!'
+}
 
 
 async def convert_config_value(ctx: Context, key: str, value: str) -> t.Any:
     """Converts a config value according to its key."""
-    if key not in CONFIG_KEYS:
+    if key not in CONFIG_DEFAULTS:
         raise ValueError('❌ There is no such config key.')
 
     if key in ('mod_role', 'admin_role'):
@@ -53,7 +57,7 @@ class Config(Cog):
     @config_group.command(name='get', aliases=('g',))
     async def get_command(self, ctx: Context, key: str) -> None:
         """Get the value of `key` from a guild's config."""
-        if key not in CONFIG_KEYS:
+        if key not in CONFIG_DEFAULTS:
             await ctx.send('❌ There is no such config key.')
             return
 
@@ -63,13 +67,13 @@ class Config(Cog):
     @config_group.command(name='reset', aliases=('r',))
     async def reset_command(self, ctx: Context, key: str) -> None:
         """Reset the value of `key` in a guild's config."""
-        if key not in CONFIG_KEYS:
+        if key not in CONFIG_DEFAULTS:
             await ctx.send('❌ There is no such config key.')
             return
 
         await self.bot.api_client.patch(
             f'guild_configs/{ctx.guild.id}',
-            json={key: None}
+            json={key: CONFIG_DEFAULTS[key]}
         )
         await ctx.send(f'✅ Config key `{key}` was sucessfully reset.')
 

--- a/snek/exts/core/help_command.py
+++ b/snek/exts/core/help_command.py
@@ -150,9 +150,10 @@ class CustomHelpCommand(HelpCommand):
 
         parent = command.full_parent_name
         name = str(command) if not parent else f'{parent} {command.name}'
+        prefix = self.context.bot.configs[self.context.guild.id]['command_prefix']
 
         # Show command signature
-        command_details = f'**```!{name} {command.signature}```**\n'
+        command_details = f'**```{prefix}{name} {command.signature}```**\n'
 
         # Show aliases
         aliases = ', '.join(
@@ -177,16 +178,17 @@ class CustomHelpCommand(HelpCommand):
         message = await self.context.send(embed=embed)
         await help_cleanup(self.context.bot, self.context.author, message)
 
-    @staticmethod
     def get_command_details(
-        commands: t.List[Command], return_as_list: bool = False
+        self, commands: t.List[Command], return_as_list: bool = False
     ) -> t.Union[t.List[str], str]:
         """Format the prefix, command name, signature, and short docs."""
         details = list()
+        prefix = self.context.bot.configs[self.context.guild.id]['command_prefix']
+
         for command in commands:
             signature = f' {command.signature}' if command.signature else ''
             details.append(
-                f'\n**`!{command.qualified_name}{signature}`**'
+                f'\n**`{prefix}{command.qualified_name}{signature}`**'
                 f'\n*{command.short_doc or "No details provided."}*'
             )
 

--- a/snek/exts/syncer/syncers/guild.py
+++ b/snek/exts/syncer/syncers/guild.py
@@ -47,3 +47,7 @@ class GuildSyncer(ObjectSyncerABC):
         log.trace('Syncing updated guilds..')
         for guild in diff.updated:
             await self.bot.api_client.put(f'guilds/{guild.id}', json=guild._asdict())
+
+        log.trace('Syncing all guild configs..')
+        configs = await self.bot.api_client.get('guild_configs')
+        self.bot.configs = {config['guild']: config for config in configs}


### PR DESCRIPTION
## Description
This PR makes the bot pull the guild configs at startup to cache them, so the API is not called every time we need a config value. 

I've also added the `command_prefix` config key, so the bot's prefix can now be set per guild by administrators.