### PR TITLE
Create the Infractions cog for the Moderation Extension

### DIFF
--- a/snek/exts/moderation/__init__.py
+++ b/snek/exts/moderation/__init__.py
@@ -1,0 +1,5 @@
+from snek.bot import Snek
+
+
+def setup(bot: Snek) -> None:
+    """Load the `moderation` cogs."""

--- a/snek/utils/__init__.py
+++ b/snek/utils/__init__.py
@@ -1,3 +1,4 @@
 from snek.utils.paginator import LinePaginator, PaginatedEmbed
+from snek.utils.scheduler import Scheduler
 
-__all__ = ('LinePaginator', 'PaginatedEmbed')
+__all__ = ('LinePaginator', 'PaginatedEmbed', 'Scheduler')

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -103,6 +103,13 @@ class Scheduler:
             task.cancel()
             self.log.debug(f'Task #{task_id} successfully unscheduled.')
 
+    def cancel_all(self) -> None:
+        """Unschedule all tasks."""
+        self.log.debug('Unscheduling all tasks..')
+
+        for task_id in self.tasks.copy():
+            self.cancel(task_id)
+
     async def _future_await(self, delay: t.Union[int, float], task_id: t.Hashable, coroutine: t.Coroutine) -> None:
         try:
             self.log.trace(f'Waiting {delay} seconds before awaiting task #{task_id}.')

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -65,6 +65,15 @@ class Scheduler:
         self[task_id] = task
         self.log.debug(f'Scheduled task #{task_id}.')
 
+    def schedule_in(self, seconds: t.Union[int, float], task_id: t.Hashable, coroutine: t.Coroutine) -> None:
+        """
+        Schedule a coroutine to be awaited for `seconds` seconds.
+
+        If a task with `task_id` already exists, the coroutine will be closed
+        instead of scheduling it. This prevents unawaited coroutine warnings.
+        """
+        self.schedule(task_id, self._future_await(seconds, coroutine))
+
     async def _future_await(self, delay: t.Union[int, float], task_id: t.Hashable, coroutine: t.Coroutine) -> None:
         try:
             self.log.trace(f'Waiting {delay} seconds before awaiting task #{task_id}.')

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -33,6 +33,6 @@ class Scheduler:
         """Sets the coroutine to the `task_id`."""
         self.tasks[task_id] = task
 
-    def get(self, task_id: t.Hashable) -> t.Coroutine:
+    def get(self, task_id: t.Hashable) -> t.Optional[asyncio.Task]:
         """Returns the coroutine mapped to `task_id`; Returns `None` if not found."""
         return self.tasks.get(task_id)

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+from datetime import datetime
 import functools
 import inspect
 import logging
@@ -64,6 +65,20 @@ class Scheduler:
 
         self[task_id] = task
         self.log.debug(f'Scheduled task #{task_id}.')
+
+    def schedule_at(self, datetime_: datetime, task_id: t.Hashable, coroutine: t.Coroutine) -> None:
+        """
+        Schedule a coroutine to be awaited at `datetime`.
+
+        If a task with `task_id` already exists, the coroutine will be closed
+        instead of scheduling it. This prevents unawaited coroutine warnings.
+        """
+        seconds = (datetime_ - datetime.now()).total_seconds()
+
+        if seconds > 0:
+            coroutine = self._future_await(seconds, task_id, coroutine)
+
+        self.schedule(task_id, coroutine)
 
     def schedule_in(self, seconds: t.Union[int, float], task_id: t.Hashable, coroutine: t.Coroutine) -> None:
         """

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -89,6 +89,20 @@ class Scheduler:
         """
         self.schedule(task_id, self._future_await(seconds, task_id, coroutine))
 
+    def cancel(self, task_id: t.Hashable) -> None:
+        """Unschedule the task mapped to `task_id`."""
+        self.log.trace(f'Cancelling task #{task_id}')
+
+        try:
+            task = self.tasks.pop(task_id)
+
+        except KeyError:
+            self.log.warning(f'Failed to unschedule task #{task_id}; task was not found.')
+
+        else:
+            task.cancel()
+            self.log.debug(f'Task #{task_id} successfully unscheduled.')
+
     async def _future_await(self, delay: t.Union[int, float], task_id: t.Hashable, coroutine: t.Coroutine) -> None:
         try:
             self.log.trace(f'Waiting {delay} seconds before awaiting task #{task_id}.')

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -24,3 +24,15 @@ class Scheduler:
     def __contains__(self, task_id: t.Hashable) -> bool:
         """Checks whether or not `task_id` is currently scheduled."""
         return task_id in self.tasks
+
+    def __getitem__(self, task_id: t.Hashable) -> t.Coroutine:
+        """Returns the coroutine mapped to `task_id`; Raises a `KeyError` if not found."""
+        return self.tasks[task_id]
+
+    def __setitem__(self, task_id: t.Hashable, coroutine: t.Coroutine) -> None:
+        """Sets the coroutine to the `task_id`."""
+        self.tasks[task_id] = coroutine
+
+    def get(self, task_id: t.Hashable) -> t.Coroutine:
+        """Returns the coroutine mapped to `task_id`; Returns `None` if not found."""
+        return self.tasks.get(task_id)

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -20,3 +20,7 @@ class Scheduler:
 
         self.log = logging.getLogger(f'{name} {type(self).__name__}')
         self.tasks: t.Dict[t.Hashable, asyncio.Task] = dict()
+
+    def __contains__(self, task_id: t.Hashable) -> bool:
+        """Checks whether or not `task_id` is currently scheduled."""
+        return task_id in self.tasks

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -1,0 +1,22 @@
+import asyncio
+import logging
+import typing as t
+
+
+class Scheduler:
+    """
+    Schedules and tracks the execution of coroutines.
+
+    The give name is for logging purposes. Using the name of the class
+    or module is strongly suggested.
+
+    Each coroutine needs a unique ID in ordre to keep track of them.
+
+    Any exception raised in a scheduled task is logged when the task is done.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+        self.log = logging.getLogger(f'{name} {type(self).__name__}')
+        self.tasks: t.Dict[t.Hashable, asyncio.Task] = dict()

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -25,13 +25,13 @@ class Scheduler:
         """Checks whether or not `task_id` is currently scheduled."""
         return task_id in self.tasks
 
-    def __getitem__(self, task_id: t.Hashable) -> t.Coroutine:
+    def __getitem__(self, task_id: t.Hashable) -> asyncio.Task:
         """Returns the coroutine mapped to `task_id`; Raises a `KeyError` if not found."""
         return self.tasks[task_id]
 
-    def __setitem__(self, task_id: t.Hashable, coroutine: t.Coroutine) -> None:
+    def __setitem__(self, task_id: t.Hashable, task: asyncio.Task) -> None:
         """Sets the coroutine to the `task_id`."""
-        self.tasks[task_id] = coroutine
+        self.tasks[task_id] = task
 
     def get(self, task_id: t.Hashable) -> t.Coroutine:
         """Returns the coroutine mapped to `task_id`; Returns `None` if not found."""

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -72,7 +72,7 @@ class Scheduler:
         If a task with `task_id` already exists, the coroutine will be closed
         instead of scheduling it. This prevents unawaited coroutine warnings.
         """
-        self.schedule(task_id, self._future_await(seconds, coroutine))
+        self.schedule(task_id, self._future_await(seconds, task_id, coroutine))
 
     async def _future_await(self, delay: t.Union[int, float], task_id: t.Hashable, coroutine: t.Coroutine) -> None:
         try:

--- a/snek/utils/scheduler.py
+++ b/snek/utils/scheduler.py
@@ -45,7 +45,7 @@ class Scheduler:
         """
         Schedule the execution of a coroutine.
 
-        It a task with `task_id` already exists, the coroutine will be closed
+        If a task with `task_id` already exists, the coroutine will be closed
         instead of scheduling it. This prevents unawaited coroutine warnings.
         """
         self.log.trace(f'Scheduling task #{task_id}.')


### PR DESCRIPTION
## Description
This PR will create the moderation extension, but specifically focus on the infractions cog. 

To be DRY, I've created a general scheduler and put it into the `utils` directory so it can be used for other purposes. Then, I created an infractions scheduler, specific for infractions. All temporary infractions (tempmute, tempban, force nick) are scheduled to end using the infractions scheduler.

## Features
- [ ] Infractions Cog
    - [ ] Ban
    - [ ] Unban
    - [ ] Mute
    - [ ] Unmute
    - [ ] Kick
    - [ ] Temporary ban
    - [ ] Temporary mute
    - [ ] Watchdog
    - [ ] Force nick
    - [ ] Multi-ban
    - [ ] Multi-mute
    - [ ] Multi-kick