### PR TITLE
Create the slowmode cog

### DIFF
--- a/snek/exts/moderation/__init__.py
+++ b/snek/exts/moderation/__init__.py
@@ -1,0 +1,8 @@
+from snek.bot import Snek
+from snek.exts.moderation.slowmode import Slowmode
+
+
+def setup(bot: Snek) -> None:
+    """Load the `moderation` cogs."""
+    bot.add_cog(Slowmode(bot))
+

--- a/snek/exts/moderation/__init__.py
+++ b/snek/exts/moderation/__init__.py
@@ -5,4 +5,3 @@ from snek.exts.moderation.slowmode import Slowmode
 def setup(bot: Snek) -> None:
     """Load the `moderation` cogs."""
     bot.add_cog(Slowmode(bot))
-

--- a/snek/exts/moderation/slowmode.py
+++ b/snek/exts/moderation/slowmode.py
@@ -87,8 +87,3 @@ class Slowmode(Cog):
     async def cog_check(self, ctx: Context) -> bool:
         """Only allow moderators to invoke the commands in this cog."""
         return discord.utils.get(ctx.author.roles, id=self.bot.configs[ctx.guild.id]['mod_role'])
-
-
-def setup(bot: Snek) -> None:
-    """Load the Slowmode cog."""
-    bot.add_cog(Slowmode(bot))

--- a/snek/exts/moderation/slowmode.py
+++ b/snek/exts/moderation/slowmode.py
@@ -1,0 +1,95 @@
+import logging
+from datetime import datetime
+from typing import Optional
+
+import discord
+import humanize
+from discord import TextChannel
+from discord.ext.commands import Cog, Context, group
+
+from snek.bot import Snek
+from snek.utils.converters import DurationDelta
+
+log = logging.getLogger(__name__)
+
+SLOWMODE_MAX_DELAY = 21600  # seconds
+
+
+class Slowmode(Cog):
+    """Commands for getting and setting slowmode delays of text channels."""
+
+    def __init__(self, bot: Snek) -> None:
+        self.bot = bot
+
+    @group(name='slowmode', aliases=['sm'], invoke_without_command=True)
+    async def slowmode_group(self, ctx: Context) -> None:
+        """Get or set the slowmode delay for the text channel this was invoked in or a given text channel."""
+        await ctx.send_help(ctx.command)
+
+    @slowmode_group.command(name='get', aliases=['g'])
+    async def get_slowmode(self, ctx: Context, channel: Optional[TextChannel]) -> None:
+        """Get the slowmode delay for a text channel."""
+        # Use the channel this command was invoked in if one was not given
+        if channel is None:
+            channel = ctx.channel
+
+        humanized_delay = humanize.precisedelta(channel.slowmode_delay, minimum_unit='seconds', format=r'%0.0f')
+
+        await ctx.send(f'The slowmode delay for {channel.mention} is {humanized_delay}.')
+
+    @slowmode_group.command(name='set', aliases=['s'])
+    async def set_slowmode(self, ctx: Context, channel: Optional[TextChannel], delay: DurationDelta) -> None:
+        """Set the slowmode delay for a text channel."""
+        # Use the channel this command was invoked in if one was not given
+        if channel is None:
+            channel = ctx.channel
+
+        # Convert `dateutil.relativedelta.relativedelta` to `datetime.timedelta`
+        # Must do this to get the delta in a particular unit of time
+        utcnow = datetime.utcnow()
+        slowmode_delay = (utcnow + delay - utcnow).total_seconds()
+
+        humanized_delay = humanize.precisedelta(slowmode_delay, minimum_unit='seconds', format=r'%0.0f')
+
+        # Ensure the delay is within discord's limits
+        if slowmode_delay <= SLOWMODE_MAX_DELAY:
+            log.info(f'{ctx.author} set the slowmode delay for #{channel} to {humanized_delay}.')
+
+            await channel.edit(slowmode_delay=slowmode_delay)
+            await ctx.send(
+                f'✅ The slowmode delay for {channel.mention} is now {humanized_delay}.'
+            )
+
+        else:
+            log.info(
+                f'{ctx.author} tried to set the slowmode delay of #{channel} to {humanized_delay}, '
+                'which is not between 0 and 6 hours.'
+            )
+
+            await ctx.send(
+                '❌ The slowmode delay must be between 0 and 6 hours.'
+            )
+
+    @slowmode_group.command(name='reset', aliases=['r'])
+    async def reset_slowmode(self, ctx: Context, channel: Optional[TextChannel]) -> None:
+        """Reset the slowmode delay for a text channel to 0 seconds."""
+        # Use the channel this command was invoked in if one was not given
+        if channel is None:
+            channel = ctx.channel
+
+        log.info(f'{ctx.author} reset the slowmode delay for #{channel} to 0 seconds.')
+
+        await channel.edit(slowmode_delay=0)
+        await ctx.send(
+            f'✅ The slowmode delay for {channel.mention} has been reset to 0 seconds.'
+        )
+
+    async def cog_check(self, ctx: Context) -> bool:
+        """Only allow moderators to invoke the commands in this cog."""
+        return discord.utils.get(ctx.author.roles, id=self.bot.configs[ctx.guild.id]['mod_role'])
+
+
+def setup(bot: Snek) -> None:
+    """Load the Slowmode cog."""
+    bot.add_cog(Slowmode(bot))
+

--- a/snek/exts/moderation/slowmode.py
+++ b/snek/exts/moderation/slowmode.py
@@ -92,4 +92,3 @@ class Slowmode(Cog):
 def setup(bot: Snek) -> None:
     """Load the Slowmode cog."""
     bot.add_cog(Slowmode(bot))
-

--- a/snek/utils/converters.py
+++ b/snek/utils/converters.py
@@ -1,0 +1,64 @@
+import re
+
+from dateutil.relativedelta import relativedelta
+from discord.ext.commands import BadArgument, Context, Converter
+
+
+class DurationDelta(Converter):
+    """Convert duration strings into dateutil.relativedelta.relativedelta objects.
+    
+    MIT License
+
+    Copyright (c) 2018 Python Discord
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """
+
+    duration_parser = re.compile(
+        r"((?P<years>\d+?) ?(years|year|Y|y) ?)?"
+        r"((?P<months>\d+?) ?(months|month|m) ?)?"
+        r"((?P<weeks>\d+?) ?(weeks|week|W|w) ?)?"
+        r"((?P<days>\d+?) ?(days|day|D|d) ?)?"
+        r"((?P<hours>\d+?) ?(hours|hour|H|h) ?)?"
+        r"((?P<minutes>\d+?) ?(minutes|minute|M) ?)?"
+        r"((?P<seconds>\d+?) ?(seconds|second|S|s))?"
+    )
+
+    async def convert(self, ctx: Context, duration: str) -> relativedelta:
+        """
+        Converts a `duration` string to a relativedelta object.
+        The converter supports the following symbols for each unit of time:
+        - years: `Y`, `y`, `year`, `years`
+        - months: `m`, `month`, `months`
+        - weeks: `w`, `W`, `week`, `weeks`
+        - days: `d`, `D`, `day`, `days`
+        - hours: `H`, `h`, `hour`, `hours`
+        - minutes: `M`, `minute`, `minutes`
+        - seconds: `S`, `s`, `second`, `seconds`
+        The units need to be provided in descending order of magnitude.
+        """
+        match = self.duration_parser.fullmatch(duration)
+        if not match:
+            raise BadArgument(f"`{duration}` is not a valid duration string.")
+
+        duration_dict = {unit: int(amount) for unit, amount in match.groupdict(default=0).items()}
+        delta = relativedelta(**duration_dict)
+
+        return delta
+

--- a/snek/utils/converters.py
+++ b/snek/utils/converters.py
@@ -6,7 +6,7 @@ from discord.ext.commands import BadArgument, Context, Converter
 
 class DurationDelta(Converter):
     """Convert duration strings into dateutil.relativedelta.relativedelta objects.
-    
+
     MIT License
 
     Copyright (c) 2018 Python Discord
@@ -61,4 +61,3 @@ class DurationDelta(Converter):
         delta = relativedelta(**duration_dict)
 
         return delta
-


### PR DESCRIPTION
## Description
This cog allows moderators to control the slowmode delay of channels.

Closes #6.

## Commands
- `!slowmode get [channel]`
- `!slowmode set [channel] <delay>`
- `!slowmode reset [channel]`

If a channel is not given for any of these commands, the channel the command is invoked in is used.