### PR TITLE
Create the bookmark cog

### DIFF
--- a/snek/exts/bookmark.py
+++ b/snek/exts/bookmark.py
@@ -31,6 +31,13 @@ class Bookmark(Cog):
             url='https://cdn.iconscout.com/icon/free/png-32/bookmark-1754138-1493251.png'
         )
 
+        for a in message.attachments:
+            if a.height is None or a.width is None:
+                continue
+
+            embed.set_image(url=a.url)
+            break
+
         try:
             await ctx.author.send(embed=embed)
         except discord.Forbidden:

--- a/snek/exts/bookmark.py
+++ b/snek/exts/bookmark.py
@@ -13,6 +13,11 @@ class Bookmark(Cog):
     @command(aliases=('bm',))
     async def bookmark(self, ctx: Context, message: discord.Message, *, title: str = '') -> None:
         """Bookmark a message to your DMs."""
+        perms = message.channel.permissions_for(ctx.author)
+        if not perms.read_messages:
+            await ctx.message.add_reaction('❌')
+            return
+
         embed = discord.Embed(
             title=title or "Bookmark",
             color=discord.Color.blurple(),

--- a/snek/exts/bookmark.py
+++ b/snek/exts/bookmark.py
@@ -27,6 +27,10 @@ class Bookmark(Cog):
             value=f'[Jump to original message]({message.jump_url})'
         )
 
+        embed.set_thumbnail(
+            url='https://cdn.iconscout.com/icon/free/png-32/bookmark-1754138-1493251.png'
+        )
+
         try:
             await ctx.author.send(embed=embed)
         except discord.Forbidden:

--- a/snek/exts/bookmark.py
+++ b/snek/exts/bookmark.py
@@ -1,0 +1,40 @@
+import discord
+from discord.ext.commands import Cog, Context, command
+
+from snek.bot import Snek
+
+
+class Bookmark(Cog):
+    """Bookmark and save messages."""
+
+    def __init__(self, bot: Snek) -> None:
+        self.bot = bot
+
+    @command(aliases=('bm',))
+    async def bookmark(self, ctx: Context, message: discord.Message, *, title: str = '') -> None:
+        """Bookmark a message to your DMs."""
+        embed = discord.Embed(
+            title=title or "Bookmark",
+            color=discord.Color.blurple(),
+            description=message.content
+        )
+        embed.set_author(
+            name=message.author,
+            icon_url=message.author.avatar_url
+        )
+        embed.add_field(
+            name='Want to visit the original message?',
+            value=f'[Jump to original message]({message.jump_url})'
+        )
+
+        try:
+            await ctx.author.send(embed=embed)
+        except discord.Forbidden:
+            await ctx.send('❌ Please open your DMs!')
+        else:
+            await ctx.message.add_reaction('✅')
+
+
+def setup(bot: Snek) -> None:
+    """Load the `Bookmark` cog."""
+    bot.add_cog(Bookmark(bot))

--- a/snek/exts/bookmark.py
+++ b/snek/exts/bookmark.py
@@ -3,6 +3,8 @@ from discord.ext.commands import Cog, Context, command
 
 from snek.bot import Snek
 
+BOOKMARK_THUMBNAIL_URL = 'https://cdn.iconscout.com/icon/free/png-32/bookmark-1754138-1493251.png'
+
 
 class Bookmark(Cog):
     """Bookmark and save messages."""
@@ -33,9 +35,7 @@ class Bookmark(Cog):
         )
 
         # Add a small bookmark thumbnail
-        embed.set_thumbnail(
-            url='https://cdn.iconscout.com/icon/free/png-32/bookmark-1754138-1493251.png'
-        )
+        embed.set_thumbnail(url=BOOKMARK_THUMBNAIL_URL)
 
         # Attach an image/video if one exists
         for a in message.attachments:

--- a/snek/exts/bookmark.py
+++ b/snek/exts/bookmark.py
@@ -32,10 +32,12 @@ class Bookmark(Cog):
             value=f'[Jump to original message]({message.jump_url})'
         )
 
+        # Add a small bookmark thumbnail
         embed.set_thumbnail(
             url='https://cdn.iconscout.com/icon/free/png-32/bookmark-1754138-1493251.png'
         )
 
+        # Attach an image/video if one exists
         for a in message.attachments:
             if a.height is None or a.width is None:
                 continue


### PR DESCRIPTION
## Description
This cog introduces a new command that allows members to bookmark and save a message. The bookmark is sent to the member via direct messages. It supports text, images, and videos.

The command ensures the user has read permissions for the channel the given message is in before sending it to them.

Closes #12.

## Command
`!bookmark <message> [title]`